### PR TITLE
[FEATURE] Add config option for custom name choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ src
 
 ```typescript
 export interface GeneratorConfig {
+  choices?: string[]; //modify the default atomic naming choices eg. ["Atom", "Molecule", "Organism", "Template", "Page"],
+
   createIndex: boolean; //create an index file
   functional: boolean; //should the template be functional or class based?
   basePath: string; //where do you want to store the generated files

--- a/src/atomicComponent.ts
+++ b/src/atomicComponent.ts
@@ -32,7 +32,10 @@ const atomicComponent = (
 		type: "list",
 		name: "type",
 		message: "component type",
-		choices: ["Atom", "Molecule", "Organism", "Template", "Page"],
+		choices:
+			fullConfig.choices !== undefined
+				? ["Atoms", "Molecules", "Organisms", "Templates", "Pages"]
+				: fullConfig.choices,
 	});
 
 	prompts.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import atomicComponent from "./atomicComponent";
 import { FileNameFormatters } from "./types";
 
 export interface GeneratorConfig {
+	choices?: string[];
 	createIndex: boolean;
 	functional: boolean;
 	basePath: string;


### PR DESCRIPTION
# Proposal
The current plop generator uses standard naming conventions from atomic design as the name suggests. 

In our workflow, we're using NextJS which includes a `pages` directory at the root of the project (which is not rename-able) used for page routes. To avoid confusion we wanted to modify that to `page-components`. 

To do this we added an option to customize the atomic name choices. This has the added benefit of letting a group use atomic design principles while being creative with how what they're called.

# Usage
The project defaults to using the original atomic names, and the config is not required to exist.

To customize the name choices, add the following option to the plopfile `atomicGenerator` config with whichever custom names you'd like to use:
```
choices: ['Atoms', 'Molecules', 'Organisms', 'PageComponents', 'Templates'],
```

 


Goal is to add an option to customize the name choices in the prompt and directories used.