### PR TITLE
[FEATURE] Add config boolean to make styles file optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ src
             ├── $ComponentName.tsx
             ├── $ComponentName.test.tsx (optional)
             ├── $ComponentName.stories.tsx (optional)
-            ├── $ComponentName.styles.tsx (optional)
+            ├── $ComponentName.styles.ts (optional)
             └── index.tsx (optional)
 ```
 
@@ -104,6 +104,7 @@ src
 ```typescript
 export interface GeneratorConfig {
   createIndex: boolean; //create an index file
+  createStyles: boolean; //create a styles file
   functional: boolean; //should the template be functional or class based?
   basePath: string; //where do you want to store the generated files
   withClassnameInterfaceImportPath: string; //from where can we import the classname interface

--- a/src/atomicComponent.ts
+++ b/src/atomicComponent.ts
@@ -226,14 +226,16 @@ const atomicComponent = (
 		}
 	}
 
-	actions.push({
-		type: "add",
-		path:
-			fullConfig.basePath +
-			`/${formattedType}/${formattedDirName}/${formattedFileName}.styles.ts`,
-		templateFile: stylesTemplateFile,
-		data,
-	});
+	if (fullConfig.createStyles === undefined || fullConfig.createStyles) {
+		actions.push({
+			type: "add",
+			path:
+				fullConfig.basePath +
+				`/${formattedType}/${formattedDirName}/${formattedFileName}.styles.ts`,
+			templateFile: stylesTemplateFile,
+			data,
+		});
+	}
 
 	return {
 		description: "⚛ react component",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { FileNameFormatters } from "./types";
 
 export interface GeneratorConfig {
 	createIndex: boolean;
+	createStyles?: boolean;
 	functional: boolean;
 	basePath: string;
 	withClassnameInterfaceImportPath: string;


### PR DESCRIPTION
# Proposal

The current plop generator includes a styles template, which is great for many group's workflows. 

In our case we are going with a one export per file approach for our styled components and the initial default file doesn't make sense. Since none of the current options seem to disable creating that file we've added that feature here. 

# Usage
By default the style file is still created and the config option is not required to exist in the list.

To disable the style file creation, add the following to the plop file `atomicGenerator` config:
```
createStyles: false,
```