### PR TITLE
[FEATURE] Add option to include custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ src
             ├── $ComponentName.test.tsx (optional)
             ├── $ComponentName.stories.tsx (optional)
             ├── $ComponentName.styles.tsx (optional)
+            ├── $ComponentName.custom.ts (optional see additionalTemplates)
             └── index.tsx (optional)
 ```
 
@@ -103,6 +104,7 @@ src
 
 ```typescript
 export interface GeneratorConfig {
+  additionalTemplates?: { extension: string; template: string }[]; //custom template extension eg. custom.ts, & template path to the corresponding files, need to be an absolute path
   createIndex: boolean; //create an index file
   functional: boolean; //should the template be functional or class based?
   basePath: string; //where do you want to store the generated files

--- a/src/atomicComponent.ts
+++ b/src/atomicComponent.ts
@@ -235,6 +235,21 @@ const atomicComponent = (
 		data,
 	});
 
+	if (fullConfig.additionalTemplates !== undefined) {
+		fullConfig.additionalTemplates.forEach(({ extension, template }) => {
+			if (fs.existsSync(template)) {
+				actions.push({
+					type: "add",
+					path:
+						fullConfig.basePath +
+						`/${formattedType}/${formattedDirName}/${formattedFileName}.${extension}`,
+					templateFile: template,
+					data,
+				});
+			}
+		});
+	}
+
 	return {
 		description: "⚛ react component",
 		prompts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import atomicComponent from "./atomicComponent";
 import { FileNameFormatters } from "./types";
 
 export interface GeneratorConfig {
+	additionalTemplates?: { extension: string; template: string }[];
 	createIndex: boolean;
 	functional: boolean;
 	basePath: string;


### PR DESCRIPTION
# Proposal
The current plop generator is a great workflow tool, and has some good standard files included with the template. 

In some cases a group's workflow may want to include other files as part of the generation. For example in our case we wanted to add a `component-name.props.ts` file with a basic scaffold of props for a component.

To support that option I've added an option to add a custom template file for example `component-name.props.ts` 

# Usage
By default the templates are unchanged from the original set, and the config is not required to exist.

The steps for a new template file include:
  1. Add a new template file to your local project. eg. `props.hbs` 
  2. Add the template as an additional template in the plopfile `atomicGenerator` config:
  ```
  additionalTemplates: [
    {
      extension: 'props.ts',
      template: 'generators/atomic-component/templates/props.hbs',
    },
  ],
  ```